### PR TITLE
feat: adds grbm abbr for `git rebase (git_main_branch)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ abbreviation | result
 `grbc` | `git rebase --continue`
 `grbd` | `git rebase (git_develop_branch)`
 `grbi` | `git rebase -i`
+`grbm` | `git rebase (git_main_branch)`
 `grbom` | `git rebase origin/(git_main_branch)`
 `grbo` | `git rebase --onto`
 `grbs` | `git rebase --skip`

--- a/conf.d/git_abbr.fish
+++ b/conf.d/git_abbr.fish
@@ -177,6 +177,7 @@ abbr grba 'git rebase --abort'
 abbr grbc 'git rebase --continue'
 abbr grbd 'git rebase (git_develop_branch)'
 abbr grbi 'git rebase -i'
+abbr grbm 'git rebase (git_main_branch)'
 abbr grbom 'git rebase origin/(git_main_branch)'
 abbr grbo 'git rebase --onto'
 abbr grbs 'git rebase --skip'
@@ -383,6 +384,7 @@ function git_abbr_uninstall --on-event git_abbr_uninstall
   abbr -e grbc
   abbr -e grbd
   abbr -e grbi
+  abbr -e grbm
   abbr -e grbom
   abbr -e grbo
   abbr -e grbs


### PR DESCRIPTION
I'm missing the `grbm` abbr to rebase with my local main branch.

inspired by: https://github.com/jhillyerd/plugin-git?tab=readme-ov-file#rebase